### PR TITLE
#7 - Adds support for multiple persisting refresh tokens in database

### DIFF
--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -56,13 +56,24 @@ namespace AlbumAPI.Controllers
             return Ok(serviceResponse);
         }
 
-        
+        //HTTP POST method
+        //Logs user out
+        // User logout is actually handled client-side - but this removes the refresh token associated with login
+        [HttpPost("Logout")]
+        public async Task<ActionResult<ServiceResponse<string>>> Logout()
+        {
+            var refreshToken = Request.Cookies["refreshToken"];
+
+            var serviceResponse = await _authRepo.Logout(refreshToken!);
+            //Return status code response
+            return Ok(serviceResponse);
+        }
+
         //HTTP POST method
         //Verifies user account
         [HttpPost("Verify")]
         public async Task<ActionResult<ServiceResponse<int>>> Verify(UserVerificationTokenDTO request)
         {
-
             var serviceResponse = await _authRepo.Verify(request.Token);
 
             if(!serviceResponse.Success)

--- a/API/Data/AuthRepository.cs
+++ b/API/Data/AuthRepository.cs
@@ -119,25 +119,65 @@ namespace AlbumAPI.Data
             return serviceResponse;
         }
 
+        // Method to log user out
+        // User logout is actually handled client-side - but this removes the refresh token associated with login
+        public async Task<ServiceResponse<string>> Logout(string refreshToken)
+        {
+            var serviceResponse = new ServiceResponse<string>();
+
+            var searchRefreshToken = string.Format("[{{\"Token\": \"{0}\"}}]", refreshToken);
+            // Look up the list of refresh tokens in the DB for the associated user to find a match
+            var user = await _context.Users
+                    .FirstOrDefaultAsync(u => EF.Functions.JsonContains(u.RefreshTokens!, searchRefreshToken));
+
+            if (user == null)
+            {
+                serviceResponse.Success = false;
+
+                //Error message
+                serviceResponse.ReturnMessage = "That user could not be found.";
+            }
+            else
+            {
+                // Remove the refresh tokens from the JSONB column.
+                user.RefreshTokens!.Remove(user.RefreshTokens.FirstOrDefault(rt => rt.Token == refreshToken)!);
+
+                serviceResponse.ReturnMessage = "Logged user out.";
+                
+                //Save changes to DB table
+                _context.Entry(user).State = EntityState.Modified;
+                await _context.SaveChangesAsync();
+            }
+            
+            return serviceResponse;
+        }
+
         //Method to validate refresh token
         public async Task<ServiceResponse<string>> ValidateRefreshToken(string refreshToken)
         {
             var serviceResponse = new ServiceResponse<string>();
 
-            // Look up the refresh token in the database
-            var user = await _context.Users.SingleOrDefaultAsync(u => u.RefreshToken.Equals(refreshToken));
+            var searchRefreshToken = string.Format("[{{\"Token\": \"{0}\"}}]", refreshToken);
+            // Look up the list of refresh tokens in the DB for the associated user to find a match
+            var user = await _context.Users
+                    .FirstOrDefaultAsync(u => EF.Functions.JsonContains(u.RefreshTokens!, searchRefreshToken));
 
-            // Check if the refresh token was found and has not expired
+            // Refresh token not found
             if (user == null){
                 serviceResponse.Success = false;
                 serviceResponse.ReturnMessage = "This refresh token does not exist.";
             }
-            else if (user != null && user.RefreshTokenExpiration < DateTime.UtcNow)
+            // Refresh token is found in list, but expired
+            else if (user != null && user.RefreshTokens!.Any(rt => rt.RefreshTokenExpiration < DateTime.UtcNow))
             {
                 serviceResponse.Success = false;
                 serviceResponse.ReturnMessage = "This refresh token is expired.";
+
+                // Remove the expired refresh token from the list of tokens
+                user.RefreshTokens!.Remove(user.RefreshTokens.FirstOrDefault(rt => rt.Token == refreshToken)!);
             }
-            else if (user != null && user.RefreshTokenExpiration > DateTime.UtcNow)
+            // Refresh token is found in list, and is valid.
+            else if (user != null && user.RefreshTokens!.Any(rt => rt.RefreshTokenExpiration > DateTime.UtcNow))
             {
                 string token = CreateToken(user);
                 var newRefreshToken = GenerateRefreshToken();
@@ -432,11 +472,20 @@ namespace AlbumAPI.Data
                 HttpOnly = true,
                 Expires = newRefreshToken.Expires
             };
-            user.RefreshToken = newRefreshToken.Token;
-            user.RefreshTokenExpiration = newRefreshToken.Expires;
-
+           
             //Append the refresh token to the cookie of the client
             _httpContextAccessor.HttpContext.Response.Cookies.Append("refreshToken", newRefreshToken.Token, cookieOptions);
+
+            // If the refresh tokens are null, initialize the object
+            user.RefreshTokens ??= new List<RefreshToken>();
+            // Set the refresh token in the user list
+            user.RefreshTokens!.Add(new RefreshToken
+            {
+                Token = newRefreshToken.Token,
+                RefreshTokenExpiration = newRefreshToken.Expires
+            });
+
+            _context.Entry(user).State = EntityState.Modified;
         }
 
         private string CreateRandomToken()

--- a/API/Data/AuthRepository.cs
+++ b/API/Data/AuthRepository.cs
@@ -167,15 +167,6 @@ namespace AlbumAPI.Data
                 serviceResponse.Success = false;
                 serviceResponse.ReturnMessage = "This refresh token does not exist.";
             }
-            // Refresh token is found in list, but expired
-            else if (user != null && user.RefreshTokens!.Any(rt => rt.RefreshTokenExpiration < DateTime.UtcNow))
-            {
-                serviceResponse.Success = false;
-                serviceResponse.ReturnMessage = "This refresh token is expired.";
-
-                // Remove the expired refresh token from the list of tokens
-                user.RefreshTokens!.Remove(user.RefreshTokens.FirstOrDefault(rt => rt.Token == refreshToken)!);
-            }
             // Refresh token is found in list, and is valid.
             else if (user != null && user.RefreshTokens!.Any(rt => rt.RefreshTokenExpiration > DateTime.UtcNow))
             {
@@ -282,7 +273,8 @@ namespace AlbumAPI.Data
                 user.PasswordResetToken = "";
                 user.ResetTokenExpires = null;
                 
-                //Create a new verification token so that all sessions will end upon next refresh
+                // Empty the list of refresh tokens, and generate a new refresh token for the user
+                user.RefreshTokens = new List<RefreshToken>();
                 var newRefreshToken = GenerateRefreshToken();
                 SetRefreshToken(user, newRefreshToken);
 
@@ -327,7 +319,8 @@ namespace AlbumAPI.Data
                 user.PasswordHash = passwordHash;
                 user.PasswordSalt = passwordSalt;
 
-                //Create a new verification token so that all sessions will end upon next refresh
+                // Empty the list of refresh tokens, and generate a new refresh token for the user
+                user.RefreshTokens = new List<RefreshToken>();
                 var newRefreshToken = GenerateRefreshToken();
                 SetRefreshToken(user, newRefreshToken);
 

--- a/API/Data/AuthRepository.cs
+++ b/API/Data/AuthRepository.cs
@@ -457,7 +457,7 @@ namespace AlbumAPI.Data
             var refreshToken = new RefreshTokenDTO
             {
                 Token = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64)),
-                Expires = DateTime.UtcNow.AddDays(1),
+                Expires = DateTime.UtcNow.AddDays(7),
                 Created = DateTime.UtcNow
             };
 

--- a/API/Data/IAuthRepository.cs
+++ b/API/Data/IAuthRepository.cs
@@ -11,6 +11,9 @@ namespace AlbumAPI.Data
         //Method to login
         Task<ServiceResponse<UserDTO>> Login(string userName, string password);
 
+        //Method to logout
+        Task<ServiceResponse<string>> Logout(string refreshToken);
+
         //Method to verify user
         Task<ServiceResponse<string>> Verify(string verifyToken);
 

--- a/API/Models/RefreshToken.cs
+++ b/API/Models/RefreshToken.cs
@@ -1,0 +1,11 @@
+/// <summary>
+/// Generic type wrapper object returned with every service call
+/// </summary>
+namespace AlbumAPI.Models
+{
+    public class RefreshToken
+    {
+        public string Token { get; set; } = string.Empty;
+        public DateTime RefreshTokenExpiration { get; set; }
+    }
+}

--- a/API/Models/User.cs
+++ b/API/Models/User.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 /// <summary>
 /// API model 
 /// Enables model-view-controller architectural pattern
@@ -15,8 +17,6 @@ namespace AlbumAPI.Models
         public DateTime Created { get; set; }
         public string VerificationToken { get; set; } = string.Empty;
         public DateTime? VerifiedAt { get; set; }
-        public string RefreshToken { get; set; } = string.Empty;
-        public DateTime RefreshTokenExpiration { get; set; }
         public string PasswordResetToken { get; set; } = string.Empty;
         public DateTime? ResetTokenExpires { get; set; }
         public string ImageURL { get; set; } = string.Empty;
@@ -24,5 +24,8 @@ namespace AlbumAPI.Models
         public List<Album>? Albums { get; set; }
         public List<UserFollowing> Followings { get; set; } = new List<UserFollowing>();
         public List<UserFollowing> Followers { get; set; } = new List<UserFollowing>();
+
+        [Column(TypeName = "jsonb")]
+        public List<RefreshToken>? RefreshTokens { get; set; }
     }
 }

--- a/client-app/src/app/api/serviceAgent.ts
+++ b/client-app/src/app/api/serviceAgent.ts
@@ -77,6 +77,7 @@ const Records = {
 // Define API endpoints for app's Account features
 const Account = {
   login: (user: UserLogin) => requests.post("Auth/Login", user),
+  logout: () => requests.post("Auth/Logout", {}),
   register: (user: UserRegister) => requests.post("Auth/Register", user),
   verify: (token: UserVerify) => requests.post("Auth/Verify", token),
   refresh: () => requests.post("Auth/RefreshToken", {}),

--- a/client-app/src/app/stores/userStore.ts
+++ b/client-app/src/app/stores/userStore.ts
@@ -77,12 +77,23 @@ export default class UserStore {
 
     // Store function that logs the user out
     // Accepts: none
-    logout = () => {
-        //Set the browser token and user object global state within the action to null
-        store.commonStore.setToken(null);
-        runInAction(() => this.user = null);
-        //Navigate to home page
-        router.navigate('/')
+    logout = async () => {
+        try {
+            // Call the API agent function to log user out
+            const response = await agent.Account.logout();
+
+            //If the REST endpoint succeeded, log out
+            if (response.success === true) {
+                //Set the browser token and user object global state within the action to null
+                store.commonStore.setToken(null);
+                runInAction(() => this.user = null);
+                //Navigate to home page
+                router.navigate('/')
+            }
+            return (response);
+        } catch (error) {
+            return (error);
+        }
     }
 
     // Store function that registers a new user to the app with the passed credentials

--- a/client-app/src/features/main/profile/ProfileButtons.tsx
+++ b/client-app/src/features/main/profile/ProfileButtons.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import ProfilePageSettings from "./settings/ProfilePageSettings";
 import { LogOutIcon, SettingsIcon } from "lucide-react";
 import ProfileFollowButton from "./follow/ProfileFollowButton";
+import { useToast } from "@/components/ui/use-toast";
 
 // Define component icons
 export const Icons = {
@@ -23,12 +24,39 @@ export const Icons = {
 function ProfileButtons() {
     const { userStore, profileStore } = useStore();
     const { isCurrentUser } = profileStore;
+
+    //Initialize toast component
+    const { toast } = useToast();
     
     /*
         Function to log the current user out
     */
-    function handleLogout() {
-        userStore.logout();
+    const handleLogout = async () => {
+        try {
+            const response: any = await userStore.logout()
+            //If the success field is true, display success toast
+            if (response.success === true) {
+                toast({
+                    title: 'Logged user out.',
+                })
+            }
+            //If the success field is false, display error msg toast
+            else {
+                toast({
+                    variant: "destructive",
+                    title: "Oh no! Something went wrong.",
+                    description: "Could not log you out at this time.",
+                })
+            }
+        } catch (error) {
+            //If there is no response at all, display general error
+            toast({
+                variant: "destructive",
+                title: "Oh no! Something went wrong.",
+                description: "Please try again later.",
+            })
+            throw (error)
+        }
     }
 
     // If the profile user is the logged in user, display content specific to that user's own profile


### PR DESCRIPTION
**Changes User Entity Framework data model**
> - string RefreshToken is now a JSONB List column in Postgres

**Creates RefreshToken Entity Framework data model**
**Adds new logic to support querying JSONB column for matching refresh token**
**New logout functionality for token deletion on front-end/back-end**
**Adds logic to clear refresh token list on password reset**
**TTL for refresh token changed to 7 days for user accessibility**